### PR TITLE
Support java-based interface definitions

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -39,11 +39,11 @@
       },
       {
         "package": "JavaCoder",
-        "repositoryURL": "https://github.com/readdle/swift-java-coder",
+        "repositoryURL": "https://github.com/heliumfoot/swift-java-coder",
         "state": {
-          "branch": null,
-          "revision": "065a7d03a5a77637ea5fc64ead050bbb93a9f8c3",
-          "version": "1.0.17"
+          "branch": "bugfix/support-double-decoding",
+          "revision": "e38d565fd1c7b90e5566b32f49e4d4408d25d2b7",
+          "version": null
         }
       }
     ]

--- a/Package.resolved
+++ b/Package.resolved
@@ -41,9 +41,9 @@
         "package": "JavaCoder",
         "repositoryURL": "https://github.com/heliumfoot/swift-java-coder",
         "state": {
-          "branch": "bugfix/support-double-decoding",
-          "revision": "e38d565fd1c7b90e5566b32f49e4d4408d25d2b7",
-          "version": null
+          "branch": null,
+          "revision": "fa4beba1803d97e788e43f4eae10cc8076532fbb",
+          "version": "1.0.18"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
 //		.package(path: "../java_swift"),
 		.package(url: "https://github.com/readdle/swift-java", .upToNextMinor(from: "0.2.4")),
 //		.package(path: "../swift-java"),
-		.package(url: "https://github.com/heliumfoot/swift-java-coder", .branch("bugfix/support-double-decoding")),
+		.package(url: "https://github.com/heliumfoot/swift-java-coder", .upToNextMinor(from: "1.0.18")),
 //		.package(path: "../swift-java-coder"),
 		.package(url: "https://github.com/readdle/swift-anycodable.git", .upToNextMinor(from: "1.0.3"))
 	],

--- a/Package.swift
+++ b/Package.swift
@@ -12,8 +12,11 @@ let package = Package(
 	],
 	dependencies: [
 		.package(url: "https://github.com/readdle/java_swift", .upToNextMinor(from: "2.1.9")),
+//		.package(path: "../java_swift"),
 		.package(url: "https://github.com/readdle/swift-java", .upToNextMinor(from: "0.2.4")),
-		.package(url: "https://github.com/readdle/swift-java-coder", .upToNextMinor(from: "1.0.17")),
+//		.package(path: "../swift-java"),
+		.package(url: "https://github.com/heliumfoot/swift-java-coder", .branch("bugfix/support-double-decoding")),
+//		.package(path: "../swift-java-coder"),
 		.package(url: "https://github.com/readdle/swift-anycodable.git", .upToNextMinor(from: "1.0.3"))
 	],
 	targets: [

--- a/Sources/HeliosKit/HeliosKit.swift
+++ b/Sources/HeliosKit/HeliosKit.swift
@@ -11,8 +11,10 @@ public protocol Bootable {
 }
 
 public extension Bootable {
-	public static func boot(packageName: String, cachePath: String) {
-		AndroidPackage = packageName
+	static func boot(packageName: String, cachePath: String) {
+		AndroidPackage = packageName.replacingOccurrences(of: ".", with: "/")
+		NSLog("[\(String(describing: self))] - Android Package = \(AndroidPackage)")
+		
 		setenv("TMPDIR", cachePath, 1)
 		// Required for SSL to work
 		setenv("URLSessionCertificateAuthorityInfoFile", cachePath + "/cacert.pem", 1)


### PR DESCRIPTION
- Use our own fork of swift-java-coder to fix optional Double decoding issues
- Fix : This global variable gets assigned the package path of the jni bridging files. We were passing the package path via the  function but it contained periods as path separators instead of forward-slashes. This broke Java Class and Field reference caches JNICore+JavaCoder because the our manual implementations of JavaBridgeable used our global  value (with periods as package/path separators) and the generated swift code produced by swift-java-codgen was passing package paths using forward-slashes. So naturally, we would frequently get fieldNotFoundExceptions. This was totally my fault haha