### PR TITLE
Add `Set` to JavaBridgeable Collections with Scoped `AndroidPackage` path

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,11 +13,12 @@ let package = Package(
 	dependencies: [
         .package(name: "java_swift", url: "https://github.com/readdle/java_swift", .upToNextMinor(from: "2.1.9")),
 //		.package(path: "../java_swift"),
-        .package(name: "Java", url: "https://github.com/readdle/swift-java", .upToNextMinor(from: "0.2.4")),
+        .package(name: "Java", url: "https://github.com/readdle/swift-java", .upToNextMinor(from: "0.2.5")),
 //		.package(path: "../swift-java"),
-        .package(name: "JavaCoder", url: "https://github.com/heliumfoot/swift-java-coder", from: "1.0.19"),
-//		.package(path: "../swift-java-coder"),
-        .package(name: "AnyCodable", url: "https://github.com/readdle/swift-anycodable.git", .upToNextMinor(from: "1.0.3"))
+        .package(name: "JavaCoder", url: "https://github.com/heliumfoot/swift-java-coder", from: "1.0.20"),
+//            .package(name: "JavaCoder", url: "https://github.com/readdle/swift-java-coder", .branch("dev/kotlin-support")),
+//        .package(name: "JavaCoder", path: "../swift-java-coder"),
+        .package(name: "AnyCodable", url: "https://github.com/readdle/swift-anycodable.git", .upToNextMinor(from: "1.1.0"))
 	],
 	targets: [
 		.target(

--- a/Sources/HeliosKit/Collections+JavaBridgeable.swift
+++ b/Sources/HeliosKit/Collections+JavaBridgeable.swift
@@ -37,3 +37,17 @@ public extension Dictionary where Key: Encodable, Value: Encodable {
 		}
 
 }
+
+extension Set where Element: Decodable {
+  // Decoding SwiftValue type with JavaCoder
+  public static func from(javaObject: jobject) throws -> Self {
+      return try JavaDecoder(forPackage: AndroidPackage, missingFieldsStrategy: .throw).decode(Self.self, from: javaObject)
+  }
+}
+
+extension Set where Element: Encodable {
+  public func javaObject() throws -> jobject {
+    // ignore forPackage for basic impl
+    return try JavaEncoder(forPackage: AndroidPackage, missingFieldsStrategy: .throw).encode(self)
+  }
+}


### PR DESCRIPTION
By default `Set` is bridgeable but it's at a high level with no package. In this case, `AndroidPackage` is set to the package path configured by the HeliosKit `Bootable` infrastructure. 
